### PR TITLE
actions: build_and_deploy: fix Issue #17

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         password: ${{ secrets.PASSPHRASE }}
-        source: README.md
+        source: build/
         target: public_html/vicharak.in/docs/vaaman/
 
     - name: Copying html files to index directory


### PR DESCRIPTION
scp-action was only copying the README.md. This was caused by fragments left in the code while I was testing it.

Now, it should copy the build directory entirely to the remote server.