### PR TITLE
build_and_deploy: scp-action and ssh-action refactor

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,41 +1,42 @@
-# TODO:
-# 1. do not use ssh-action, copy files to the right directory only with scp-action
-# 2. check caching of dependencies, whether they are being reinstalled or not
+# This action does the following:
+# 1. Installs pipenv via python-pip
+# 2. Installs dependencies according to Pipfile
+# 3. Builds the documentation 
+# 4. Uses scp to copy the build files (html) to remote server
+
 
 name: Build and Deploy Vaaman Documentation
 on:
   push:
-    branches:
+    branches: 
       - main
+      - staging
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    # Install dependencies and build the docs
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - name: Setting Up Python Version 
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: Installing pipenv
-      run: python3 -m pip install pipenv
-    - name: Build docs
-      run: pipenv update && pipenv run make html -j$(nproc --all)
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install pipenv
+    - name: Installing Dependencies and Building Docs
+      run: pipenv update &&  pipenv run make html -j$(nproc --all)
 
+    # Copy it to the server
     - name: Copying build/html/ to remote server
       uses: appleboy/scp-action@v0.1.4
       with:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
         password: ${{ secrets.PASSPHRASE }}
-        source: build/
+        strip_components: 2
+        overwrite: true
+        source: _build/html/
         target: public_html/vicharak.in/docs/vaaman/
-
-    - name: Copying html files to index directory
-      uses: fifsky/ssh-action@master
-      with:
-        command: |
-          cd public_html/vicharak.in/docs/vaaman/
-          cp -r build/html/* ./
-        host: ${{ secrets.HOST }}
-        user: ${{ secrets.USERNAME }}
-        pass: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
scp-action is capable of tar-ing and untar-ing files, moreover it can strip_components (i.e. flatten nested directories) which is why ssh-action was being used previously. Since, scp-action can do all the stuff ssh-action was being used to do, it becomes redundant.

Fixes https://github.com/vicharak-in/vaaman-doc/issues/41
Closes https://github.com/vicharak-in/vaaman-doc/issues/21