### PR TITLE
Axon: Use gpio.md page instead of gpio.rst

### DIFF
--- a/source/vicharak_sbcs/axon/peripherals/gpio.rst
+++ b/source/vicharak_sbcs/axon/peripherals/gpio.rst
@@ -1,9 +1,0 @@
-##############
-GPIO
-##############
-
-.. note::
-
-   **Documentation coming soon!** 
-   This section will cover how to configure and interact with General Purpose Input/Output (GPIO) pins on Axon.
-


### PR DESCRIPTION
To access the GPIO Page, two files are over there and only one can be accessible. `gpio.md` file has content to show, whereas `gpio.rst` file is empty and it is need to be deleted.