### PR TITLE
Vaaman & Axon : Serial UART Pin Configuration for debugging purpose

### DIFF
--- a/source/vicharak_sbcs/axon/axon-getting-started.rst
+++ b/source/vicharak_sbcs/axon/axon-getting-started.rst
@@ -240,6 +240,11 @@ To access Axon through the serial interface, you will need the following:
   (such as PuTTY or minicom).
 - A USB to UART serial cable or adapter (such as FTDI or PL2303).
 - Micro USB or USB-C cable.
+- 3 Pin Jumper Wire ( Tx, Rx and GND )
+
+.. warning::
+
+    When UART (FTDI/PL2303) is connected to Axon, and Axon is poweroff. It requires to disconnect it from Axon, in order to turn on Axon Again.
 
 Hardware Setup
 ``````````````

--- a/source/vicharak_sbcs/axon/axon-getting-started.rst
+++ b/source/vicharak_sbcs/axon/axon-getting-started.rst
@@ -259,10 +259,10 @@ Hardware Setup
    * - GND
      - Pin 6
      - GND
-   * - TX
+   * - RX
      - Pin 4 (GPIO0_B5)
      - UART2_TX_M0_DEBUG
-   * - RX
+   * - TX
      - Pin 2 (GPIO0_B6)
      - UART2_RX_M0_DEBUG
 

--- a/source/vicharak_sbcs/vaaman/vaaman-getting-started.rst
+++ b/source/vicharak_sbcs/vaaman/vaaman-getting-started.rst
@@ -238,10 +238,10 @@ Hardware Setup
    * - GND
      - Pin 6
      - GND
-   * - TX
+   * - RX
      - Pin 8 (GPIO4_C4)
      - UART2DBG_TX
-   * - RX
+   * - TX
      - Pin 10 (GPIO4_C3)
      - UART2DBG_RX
 

--- a/source/vicharak_sbcs/vaaman/vaaman-getting-started.rst
+++ b/source/vicharak_sbcs/vaaman/vaaman-getting-started.rst
@@ -219,7 +219,11 @@ To access Vaaman through the serial interface, you will need:
 1. A computer with a serial terminal application installed, such as PuTTY or minicom.
 2. A USB to UART serial cable or adapter (e.g., FTDI or PL2303).
 3. A Micro USB or USB-C cable.
-4. A 4-pin jumper wire.
+4. A 3-pin jumper wire. ( Tx, Rx and GND )
+
+.. warning::
+
+    When you power off Vaaman, and want to turn on again make sure that you have disconnected ( FTDI / PL2303 ) UART from Vaaman.
 
 Hardware Setup
 --------------


### PR DESCRIPTION
- Pins should be connected in an alternative for Vaaman And Axon

````
Tx of FTDI -- Rx of Vaaman/Axon
Rx of FTDI -- Tx Of Vaaman/Axon
`````

Vaaman
-----

Mention warning in documentation,
- If UART ( FTDI) is connected to Vaaman, and User Power off Vaaman, and again try to turn on Vaaman, UART should be removed from Vaaman.

Axon
------
- When UART (FTDI/PL2303) is connected to Axon, and Axon is poweroff. It requires to disconnect it from Axon, in order to turn on Axon Again.

