### PR TITLE
Axon & Vaaman : Automatically Set Wifi on first boot

### DIFF
--- a/source/vicharak_sbcs/axon/axon-getting-started.rst
+++ b/source/vicharak_sbcs/axon/axon-getting-started.rst
@@ -305,28 +305,29 @@ Running the Serial Console Program
 
 .. include:: ../common/common-ssh.rst
 
-4. Set up automatic Wi-Fi connection on boot
---------------------------------------------
-
-In the following example, we will set up automatic Wi-Fi connection on boot
-for the **wlan0** interface. This will be useful if you are using a
-headless system. That means you will not need to connect a monitor, keyboard,
-or mouse to your system to connect to WiFi.
-
-**1. Edit the ** ``/usr/lib/vicharak-config/conf.d/before.txt`` ** file and add
-the following lines:**
-
-::
-
-    connect-wi-fi <network name> <password>
-
-Example:
-
-::
-
-    connect-wi-fi vicharak_5g vcaa_g123
-
-**2. Reboot the system.**
+..
+    4. Set up automatic Wi-Fi connection on boot
+    --------------------------------------------
+    
+    In the following example, we will set up automatic Wi-Fi connection on boot
+    for the **wlan0** interface. This will be useful if you are using a
+    headless system. That means you will not need to connect a monitor, keyboard,
+    or mouse to your system to connect to WiFi.
+    
+    **1. Edit the ** ``/usr/lib/vicharak-config/conf.d/before.txt`` ** file and add
+    the following lines:**
+    
+    ::
+    
+        connect-wi-fi <network name> <password>
+    
+    Example:
+    
+    ::
+    
+        connect-wi-fi vicharak_5g vcaa_g123
+    
+    **2. Reboot the system.**
 
 Axon Boot modes
 =================

--- a/source/vicharak_sbcs/vaaman/vaaman-getting-started.rst
+++ b/source/vicharak_sbcs/vaaman/vaaman-getting-started.rst
@@ -404,25 +404,26 @@ To access Vaaman via SSH, you can use either of the following commands:
 .. tip::
     The default username is **"vicharak"** and the default password is **"12345"**.
 
-4. Set up automatic Wi-Fi connection on boot
---------------------------------------------
-
-1. Edit the ``/usr/lib/vicharak-config/conf.d/before.txt`` file.
-
-   - Add the following line:
-     ``
-     connect_wi-fi <network name> <password>
-     ``
-
-     Example:
-     ``
-     connect_wi-fi vicharak_5g vcaa_g123
-     ``
-
-2. Reboot the system.
-
-- **Vaaman Boot modes**
-
+..
+    4. Set up automatic Wi-Fi connection on boot
+    --------------------------------------------
+    
+    1. Edit the ``/usr/lib/vicharak-config/conf.d/before.txt`` file.
+    
+       - Add the following line:
+         ``
+         connect_wi-fi <network name> <password>
+         ``
+    
+         Example:
+         ``
+         connect_wi-fi vicharak_5g vcaa_g123
+         ``
+    
+    2. Reboot the system.
+    
+Vaaman Boot modes
+================
 
 .. list-table::
    :widths: 20 40


### PR DESCRIPTION
  - It works only in first boot and mostly it can be used in building custom image and user add wifi credential