### PR TITLE
axon-downloads.rst: add link for ubuntu 24.04 downloads

### DIFF
--- a/source/vicharak_sbcs/axon/axon-downloads.rst
+++ b/source/vicharak_sbcs/axon/axon-downloads.rst
@@ -17,7 +17,9 @@ OS Images
     - - Debian
       - **Coming Soon**
     - - Ubuntu
-      - `Jammy 22.04 <https://downloads.vicharak.in/vicharak-axon/>`_
+      - `Jammy 22.04 <https://downloads.vicharak.in/vicharak-axon/ubuntu/22_jammy>`_
+    - - Ubuntu
+      - `Noble 24.04 <https://downloads.vicharak.in/vicharak-axon/ubuntu/24_noble>`_
     - - Community Images
       - **Coming Soon**
 


### PR DESCRIPTION
This commit modifies the Ubuntu 22.04 link to use a direct download URL and adds a new link for Ubuntu 24.04 for future compatibility and use.