### PR TITLE
vaaman: add yocto boot logo instructions for sd card booting

### DIFF
--- a/source/vicharak_sbcs/vaaman/vaaman-linux/linux-configuration-guide/change-boot-logo.rst
+++ b/source/vicharak_sbcs/vaaman/vaaman-linux/linux-configuration-guide/change-boot-logo.rst
@@ -108,8 +108,19 @@ Here are the prerequisites for Yocto builds:
 - ``linux-rockchip`` kernel source available
 - Basic familiarity with Git and BitBake
 
+
 Replacing the logo
 ------------------
+
+Booting from SD card
+~~~~~~~~~~~~~~~~~~~~~
+
+Inside ``meta-rockchip/recipes-vicharak/psplash/files`` you'll find a
+``logo.png``. Replace it with your own logo and rebuild via Yocto; see the
+Linux SDK guide for building details: :doc:`Linux SDK <../linux-development-guide/linux-sdk>`. If you would like to add more customisations, please refer to psplash documentation.
+
+Booting from eMMC
+~~~~~~~~~~~~~~~~~
 
 Clone the kernel repository:
 


### PR DESCRIPTION
The procedure for changing logos differs when booting from SD cards in Yocto. There, one needs to use psplash in order to change anything. I've updated the relevant documentation to reflect the same.