### PR TITLE
feat(docs): add Microsoft Clarity analytics tracking

### DIFF
--- a/source/_static/js/clarity.js
+++ b/source/_static/js/clarity.js
@@ -1,0 +1,5 @@
+(function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window, document, "clarity", "script", "xtw38brdfp");

--- a/source/conf.py
+++ b/source/conf.py
@@ -109,6 +109,10 @@ html_css_files = [
     "css/fonts.css",
     "css/custom.css",
 ]
+# JS files to include
+html_js_files = [
+    "js/clarity.js",
+]
 # Theme options
 html_theme_options = {
     # sphinxawesome_theme options


### PR DESCRIPTION
Inject Clarity tracking script via Sphinx's html_js_files mechanism instead of inline HTML, keeping conf.py clean and static assets properly managed.

- Add _static/js/clarity.js containing the Clarity init snippet
- Register clarity.js in html_js_files in conf.py