### PR TITLE
axon: gpio: point to UART and I2C pages for overlay configuration

### DIFF
--- a/source/vicharak_sbcs/axon/peripherals/gpio.md
+++ b/source/vicharak_sbcs/axon/peripherals/gpio.md
@@ -246,8 +246,7 @@ where, 14 is GPIO Line ( 78 - 64 )
 
 ### How to change Functionality of GPIO Pin Like, UART, I2C etc  ?
 
-For that, we will soon provide `overlay`, on `vicharak-config`.
-
+For this refer [UART](https://docs.vicharak.in/vicharak_sbcs/axon/peripherals/uart/) and [I2C](https://docs.vicharak.in/vicharak_sbcs/axon/peripherals/i2c/) section which have `overlay`, on `vicharak-config`.
 
 
 :::{seealso}


### PR DESCRIPTION
Replace placeholder text about future overlay support in vicharak-config with direct links to the existing UART and I2C peripheral documentation, since the overlay option for configuring GPIO pin functionality (UART, I2C, etc.) is already available there.